### PR TITLE
Add vertical-align: bottom to styling demo links

### DIFF
--- a/demo-styling.html
+++ b/demo-styling.html
@@ -16,6 +16,7 @@
         pointer-events: none;
         color: transparent;
         margin-inline-start: 0.5ch;
+        vertical-align: bottom;
       }
 
       a[href^="#"]::before {


### PR DESCRIPTION
For the styling demo, adding `vertical-align: bottom;` to the # links looks much better in my limited testing.

In use on eleventeen, which in turn uses Eleventy v3 canary’s new `IdAttributePlugin` (https://github.com/11ty/eleventy/issues/3363)

- https://github.com/rdela/eleventeen/pull/41/files#diff-b36ecf76dabd05bd6d524e80e21a187d4d189d76ac4b810de5a1ed54e853deb3R37
- page: https://eleventeen.blog/about/#rainbow-mode
- post: https://eleventeen.blog/archive/thirdpost/#styled-with-syntax